### PR TITLE
Use es_PE as language; add overrides to es_PE messages file

### DIFF
--- a/configuration/globalproperties/gp_ses.xml
+++ b/configuration/globalproperties/gp_ses.xml
@@ -3,11 +3,11 @@
         <globalProperty>
             <!-- note tht default locale must be set before changing the allowed list -->
             <property>default_locale</property>
-            <value>es</value>
+            <value>es_PE</value>
         </globalProperty>
         <globalProperty>
             <property>locale.allowed.list</property>
-            <value>en, es</value>
+            <value>en, es_PE</value>
         </globalProperty>
         <globalProperty>
             <property>coreapps.defaultPatientIdentifierLocation</property>

--- a/configuration/messageproperties/messages_es_PE.properties
+++ b/configuration/messageproperties/messages_es_PE.properties
@@ -1,0 +1,2 @@
+mirebalais.mostRecentVitals.label=Último triaje
+mirebalais.mostRecentVitals.encounterDateLabel=Último triaje: {0}


### PR DESCRIPTION
![2021-11-08_14-19](https://user-images.githubusercontent.com/1031876/140827277-47b0aa09-3f76-4288-a0d1-81c1efed9892.png)
