### PR TITLE
set locale GPs in order to avoid validation failure

### DIFF
--- a/configuration/globalproperties/gp_ses.xml
+++ b/configuration/globalproperties/gp_ses.xml
@@ -1,10 +1,15 @@
 <config>
     <globalProperties>
+        <!-- we need to add es_PE as an allowed locale before setting it as a default locale -->
         <globalProperty>
-            <!-- note tht default locale must be set before changing the allowed list -->
+            <property>locale.allowed.list</property>
+            <value>en, es, es_PE</value>
+        </globalProperty>
+        <globalProperty>
             <property>default_locale</property>
             <value>es_PE</value>
         </globalProperty>
+        <!-- remove es as an allowed locale after setting es_PE as the default -->
         <globalProperty>
             <property>locale.allowed.list</property>
             <value>en, es_PE</value>


### PR DESCRIPTION
so @MiguelAHPpih  @mseaton  @brandones  I was trying to fire up my SES instance in order to review the smoke tests and ran into the issue with the locale global properties that you had been discussing.

I tried @mseaton 's suggestion to fix and it worked for me... PR for review here.  I think I got it right... :)

