### PR TITLE
update: set locale GPs in order to avoid validation failure on startup

### DIFF
--- a/configuration/globalproperties/gp_ses.xml
+++ b/configuration/globalproperties/gp_ses.xml
@@ -1,15 +1,20 @@
 <config>
     <globalProperties>
-        <!-- we need to add es_PE as an allowed locale before setting it as a default locale -->
+        <!-- set default locale to en (for some reason default on startup is en_GB) -->
+        <globalProperty>
+            <property>default_locale</property>
+            <value>en</value>
+        </globalProperty>
+        <!-- remove en_GB and other locales, add es_PE -->
         <globalProperty>
             <property>locale.allowed.list</property>
-            <value>en, es, es_PE</value>
+            <value>en, es_PE</value>
         </globalProperty>
+        <!-- set es_PE as the default now that it's been added as an allowed locale -->
         <globalProperty>
             <property>default_locale</property>
             <value>es_PE</value>
         </globalProperty>
-        <!-- remove es as an allowed locale after setting es_PE as the default -->
         <globalProperty>
             <property>locale.allowed.list</property>
             <value>en, es_PE</value>


### PR DESCRIPTION
@brandones  @mseaton  @MiguelAHPpih  I was creating an SES environment from scratch today and the locale validation failed again, so I tweaked again... I *think* the above will work for all current use cases.