### PR TITLE
UHM-6440: Remove Check-In and Vital Signs app from home page

### DIFF
--- a/configuration/pih/pih-config-peru.json
+++ b/configuration/pih/pih-config-peru.json
@@ -27,7 +27,8 @@
     "tb",
     "visitManagement",
     "visitNote",
-    "vitals"
+    "vitals",
+    "vitalsHomePageApp"
   ],
   "scheduleBackupReports": "false",
   "dashboardUrl": "/coreapps/clinicianfacing/patient.page?patientId={{patientId}}&app=pih.app.clinicianDashboard",

--- a/configuration/pih/pih-config-peru.json
+++ b/configuration/pih/pih-config-peru.json
@@ -28,7 +28,7 @@
     "visitManagement",
     "visitNote",
     "vitals",
-    "vitalsHomePageApp"
+    "vitalsHomepageApp"
   ],
   "scheduleBackupReports": "false",
   "dashboardUrl": "/coreapps/clinicianfacing/patient.page?patientId={{patientId}}&app=pih.app.clinicianDashboard",


### PR DESCRIPTION
We recently made a chance to the PIH EMR components so that the VItals Home Page app could be turned off, while keep the Vitals form on... to do this, we moved the Vitals Home Page app into a different component. This PR just makes sure that the Vitals Home Page app stays on for the Peru servers (assuming we still want this feature in Peru)